### PR TITLE
Fix VertexSlice sub-slices rendering excessive data

### DIFF
--- a/vertex.go
+++ b/vertex.go
@@ -263,7 +263,7 @@ func (va *vertexArray) end() {
 }
 
 func (va *vertexArray) draw(i, j int) {
-	gl.DrawArrays(gl.TRIANGLES, int32(i), int32(i+j))
+	gl.DrawArrays(gl.TRIANGLES, int32(i), int32(j-i))
 }
 
 func (va *vertexArray) setVertexData(i, j int, data []float32) {


### PR DESCRIPTION
`gl.DrawArrays` takes `count` as the third argument. Current solution may cause that shader (on older GPUs) would try to render data that is outside of VBO memory. So it should be `int32(j-i)` as in other parts of  the code instead of `int32(i+j)`